### PR TITLE
specify default obcluster to obcluster during build step, fix cluster…

### DIFF
--- a/oceanbase-ce/Dockerfile
+++ b/oceanbase-ce/Dockerfile
@@ -21,7 +21,7 @@ RUN obd mirror disable remote
 RUN obd cluster deploy demo -c build/deploy.yaml
 RUN obd cluster destroy -f demo
 
-RUN obd demo -c oceanbase-ce --oceanbase-ce.home_path=/root/demo --oceanbase-ce.scenario=express_oltp --oceanbase-ce.datafile_size=256M --oceanbase-ce.log_disk_size=5G && obd cluster tenant create demo -n test -o express_oltp 
+RUN obd demo -c oceanbase-ce --oceanbase-ce.home_path=/root/demo --oceanbase-ce.appname=obcluster --oceanbase-ce.scenario=express_oltp --oceanbase-ce.datafile_size=256M --oceanbase-ce.log_disk_size=5G && obd cluster tenant create demo -n test -o express_oltp 
 RUN obd cluster stop demo
 RUN cd /root/demo && tar -cvzf store.tar.gz store
 RUN rm -rf /root/demo/store && rm -rf /root/demo/log/* && rm -rf /root/demo/log_obshell/* && rm -rf /root/demo/etc/*.py && rm -rf /root/demo/etc/obshell && rm -rf /root/demo/etc/*.sql && rm -rf /root/demo/etc/*.log && rm -rf /root/demo/run/*

--- a/oceanbase-ce/boot/start.sh
+++ b/oceanbase-ce/boot/start.sh
@@ -100,7 +100,7 @@ function boot() {
 }
 
 function create_tenant() {
-    create_tenant_cmd="obd cluster tenant create ${OB_CLUSTER_NAME} -n ${OB_TENANT_NAME} -o ${OB_SCENARIO}"
+    create_tenant_cmd="obd cluster tenant create obcluster -n ${OB_TENANT_NAME} -o ${OB_SCENARIO}"
     if ! [ -z "${OB_TENANT_MIN_CPU}" ]; then
       create_tenant_cmd="${create_tenant_cmd} --min-cpu=${OB_TENANT_MIN_CPU}"
     fi;


### PR DESCRIPTION
… name when create tenant

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
specify default obcluster to obcluster during build step
correct the deploy name used to create tenant


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
