### PR TITLE
[FIX]: obproxy start the script add rpc_listen_port

### DIFF
--- a/obproxy-ce/start.sh
+++ b/obproxy-ce/start.sh
@@ -45,10 +45,10 @@ echo "$opts"
 
 if [ ! -z $CONFIG_URL ]; then
     echo "use config server"
-    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -l 2884 -n ${APP_NAME} -o observer_sys_password=${PROXYRO_PASSWORD_HASH},obproxy_config_server_url="${CONFIG_URL}",$opts --nodaemon
+    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -l 2884 -s 2885 -n ${APP_NAME} -o observer_sys_password=${PROXYRO_PASSWORD_HASH},obproxy_config_server_url="${CONFIG_URL}",$opts --nodaemon
 elif [ ! -z $RS_LIST ]; then
     echo "use rslist"
-    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -l 2884 -n ${APP_NAME} -c ${OB_CLUSTER} -r "${RS_LIST}" -o observer_sys_password=${PROXYRO_PASSWORD_HASH},$opts --nodaemon
+    cd /home/admin/obproxy && /home/admin/obproxy/bin/obproxy -p 2883 -l 2884 -s 2885 -n ${APP_NAME} -c ${OB_CLUSTER} -r "${RS_LIST}" -o observer_sys_password=${PROXYRO_PASSWORD_HASH},$opts --nodaemon
 else 
     echo "no config server or rs list"
     exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
obproxy start the script add rpc_listen_port，close ##44


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
A rpc_listen_port is required to connect to OBKV in ODP mode