### PR TITLE
fix: Update obbinlog-ce release workflow version extraction

### DIFF
--- a/.github/workflows/release-obbinlog-ce.yml
+++ b/.github/workflows/release-obbinlog-ce.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Set Version variables
         id: set_version_vars
-        run: echo "version=$(echo $tagName | grep -P '(\d*\.\d*\.\d*\.\d*-\d*)' --only-matching)" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo $tagName | sed 's/obbinlog-ce-//')" >> $GITHUB_OUTPUT
 
       - name: Build and push obbinlog-ce w/o cache
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This PR fixes the version extraction logic in the obbinlog-ce release workflow.

### Changes Made

- **Version Extraction Logic**: Changed from regex pattern to simple sed replacement
- **Flexible Tag Support**: Now supports tags like `obbinlog-ce-4.2.5-test` → extracts `4.2.5-test`
- **Simplified Logic**: Uses `sed 's/obbinlog-ce-//'` instead of complex regex