### PR TITLE
set default value of FORCE_START_WITH_ARGS

### DIFF
--- a/seekdb/Dockerfile
+++ b/seekdb/Dockerfile
@@ -11,5 +11,6 @@ RUN if [[ ${TARGETPLATFORM} == 'linux/amd64' ]] ; then yum install -y https://mi
 COPY start.sh /root/
 RUN chmod +x /root/start.sh
 ENV REPORTER=docker-seekdb
+ENV FORCE_START_WITH_ARGS="true"
 ENTRYPOINT ["/root/start.sh"]
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
set default value of FORCE_START_WITH_ARGS = true
when restart observer's container, it will use the values in oceanbase.cnf
If the user want's to use the values in observer.config.bin, set FORCE_START_WITH_ARGS = false.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
